### PR TITLE
Fixes to build project with Rust 1.45.0-nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
     "prussia_debug",
     "prussia_dma",
     "prussia_intc",
-    "prussia_gs",
     "prussia_rt",
 ]
 

--- a/biostation/src/exceptions/common/mod.rs
+++ b/biostation/src/exceptions/common/mod.rs
@@ -11,7 +11,7 @@ extern "C" {
 
 #[no_mangle]
 extern "C" fn unimplemented_common_handler() {
-    let exc_code = (cop0::Cause::load() & cop0::Cause::ExcCode).bits() >> 2;
+    let exc_code = (cop0::Cause::load() & cop0::Cause::EXC_CODE).bits() >> 2;
     let exc_code = cop0::L1Exception::try_from_common(exc_code as u8)
         .expect("Exception codes are between 1 and 13 on real hardware");
 

--- a/biostation/src/exceptions/common/mod.rs
+++ b/biostation/src/exceptions/common/mod.rs
@@ -5,7 +5,6 @@ mod syscall;
 global_asm!(include_str!("handler.S"));
 
 extern "C" {
-    #[used]
     static mut COMMON_HANDLERS: [usize; 16];
 }
 

--- a/biostation/src/exceptions/common/syscall/mod.rs
+++ b/biostation/src/exceptions/common/syscall/mod.rs
@@ -5,7 +5,6 @@ use crate::thread;
 global_asm!(include_str!("handler.S"));
 
 extern "C" {
-    #[used]
     static mut SYSCALL_HANDLERS: [usize; 128];
 
     /// Assembly dispatch function for system calls.

--- a/biostation/src/exceptions/common/syscall/mod.rs
+++ b/biostation/src/exceptions/common/syscall/mod.rs
@@ -15,7 +15,7 @@ extern "C" {
 #[no_mangle]
 extern "C" fn unimplemented_syscall_handler() {
     let syscall_num: u32;
-    unsafe { asm!("move $0, $$v1" : "=r" (syscall_num)) };
+    unsafe { llvm_asm!("move $0, $$v1" : "=r" (syscall_num)) };
     unimplemented!("Handler for syscall {:x}", syscall_num);
 }
 

--- a/biostation/src/main.rs
+++ b/biostation/src/main.rs
@@ -42,9 +42,7 @@ fn panic(info: &PanicInfo) -> ! {
 
     // Then crash to trigger the emulator.
     // This gets converted to `break` by LLVM.
-    unsafe {
-        intrinsics::abort();
-    }
+    intrinsics::abort();
 }
 
 #[no_mangle]

--- a/biostation/src/main.rs
+++ b/biostation/src/main.rs
@@ -8,7 +8,7 @@
     trivial_casts,
     trivial_numeric_casts
 )]
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(global_asm)]
 #![feature(naked_functions)]
 #![feature(core_intrinsics)]

--- a/hello-rs/src/main.rs
+++ b/hello-rs/src/main.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 extern crate panic_halt;
 extern crate prussia_bios as bios;

--- a/prussia_bios/src/lib.rs
+++ b/prussia_bios/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![deny(missing_docs)]
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 /// The Graphics Synthesizer video mode, passed to `set_gs_crt`.
 #[repr(i16)]
@@ -34,7 +34,7 @@ pub enum FieldFrameMode {
 /// Configure the Graphics Synthesizer's display controller to output a given VideoMode.
 pub fn set_gs_crt(imode: Interlacing, vmode: VideoMode, ffmode: FieldFrameMode) {
     unsafe {
-        asm!("li $$v1, 0x02; move $$a0, $0; move $$a1, $1; move $$a2, $2; syscall"
+        llvm_asm!("li $$v1, 0x02; move $$a0, $0; move $$a1, $1; move $$a2, $2; syscall"
              :
              : "r" (imode), "r" (vmode), "r" (ffmode)
              : "$$v1", "$$a0", "$$a1", "$$a2"
@@ -50,7 +50,7 @@ pub fn set_gs_crt(imode: Interlacing, vmode: VideoMode, ffmode: FieldFrameMode) 
 /// `sleep_thread`.
 pub fn exit(return_code: u32) -> ! {
     unsafe {
-        asm!("li $$v1, 0x04; move $$a0, $0; syscall"
+        llvm_asm!("li $$v1, 0x04; move $$a0, $0; syscall"
              :
              : "r" (return_code)
              : "$$v1", "$$a0"

--- a/prussia_rt/build.rs
+++ b/prussia_rt/build.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 #[cfg(not(feature = "kernel-linkfile"))]
-fn add_linkfile() -> Result<(), Box<Error>> {
+fn add_linkfile() -> Result<(), Box<dyn Error>> {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     File::create(out_dir.join("linkfile.ld"))?.write_all(include_bytes!("user-linkfile.ld"))?;
 
@@ -15,14 +15,14 @@ fn add_linkfile() -> Result<(), Box<Error>> {
 }
 
 #[cfg(feature = "kernel-linkfile")]
-fn add_linkfile() -> Result<(), Box<Error>> {
+fn add_linkfile() -> Result<(), Box<dyn Error>> {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     File::create(out_dir.join("linkfile.ld"))?.write_all(include_bytes!("kernel-linkfile.ld"))?;
 
     Ok(())
 }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     // build directory for this crate
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 

--- a/prussia_rt/src/cop0.rs
+++ b/prussia_rt/src/cop0.rs
@@ -49,14 +49,14 @@ impl Status {
     /// value of Status.
     pub fn load() -> Self {
         let status;
-        unsafe { asm!("mfc0 $0, $$12" : "=r" (status)) };
+        unsafe { llvm_asm!("mfc0 $0, $$12" : "=r" (status)) };
 
         Status { bits: status }
     }
 
     /// Store this object to the Coprocessor 0 Status register.
     pub fn store(self) {
-        unsafe { asm!("mtc0 $0, $$12" : : "r" (self.bits)) };
+        unsafe { llvm_asm!("mtc0 $0, $$12" : : "r" (self.bits)) };
     }
 }
 
@@ -87,7 +87,7 @@ impl Cause {
     /// value of Cause.
     pub fn load() -> Self {
         let cause;
-        unsafe { asm!("mfc0 $0, $$13" : "=r" (cause)) };
+        unsafe { llvm_asm!("mfc0 $0, $$13" : "=r" (cause)) };
 
         Cause { bits: cause }
     }

--- a/prussia_rt/src/cop0.rs
+++ b/prussia_rt/src/cop0.rs
@@ -64,7 +64,7 @@ bitflags! {
     /// Cause of the most recent exception.
     pub struct Cause: u32 {
         /// Level 1 exception code.
-        const ExcCode = 0x1F << 2;
+        const EXC_CODE = 0x1F << 2;
         /// Interrupt from the Interrupt Controller is pending.
         const IP2 = 1 << 10;
         /// Interrupt from the DMA Controller is pending.

--- a/prussia_rt/src/interrupts.rs
+++ b/prussia_rt/src/interrupts.rs
@@ -39,7 +39,7 @@ pub fn enable() {
 }
 
 /// Execute a closure in an interrupt-free context, preserving previous interrupt state.
-pub fn free<T: FnOnce() -> ()>(f: T) {
+pub fn free<T: FnOnce()>(f: T) {
     match status() {
         Status::Enabled => {
             disable();

--- a/prussia_rt/src/lib.rs
+++ b/prussia_rt/src/lib.rs
@@ -16,8 +16,6 @@ pub mod atomic;
 pub mod cop0;
 pub mod interrupts;
 
-use r0;
-
 // Static data initialised to zero goes in the .bss segment, which is essentially a pointer to
 // uninitialised memory. We need to zero .bss before the main program runs.
 //

--- a/prussia_rt/src/lib.rs
+++ b/prussia_rt/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![no_std]
 #![deny(missing_docs)]
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 pub mod atomic;
 pub mod cop0;


### PR DESCRIPTION
Created with this Dockerfile:

```
FROM rustlang/rust:nightly

RUN wget http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz && \
  tar -zxvf binutils-2.27.tar.gz && \
  cd binutils-2.27 && \
  ./configure --target=mips64el-none-elf && \
  make && \
  make install

RUN cargo install cargo-xbuild cargo-asm
RUN rustup component add rust-src

WORKDIR /src
CMD ["/bin/bash"]
```

Cargo output:

```
root@3b21d4261c33:/src# cargo xbuild --target ps2.json
WARNING: There is no root package to read the cargo-xbuild config from.
   Compiling prussia_rt v0.4.2 (/src/prussia_rt)
   Compiling biostation v0.0.0 (/src/biostation)
   Compiling hello-rs v0.1.0 (/src/hello-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 5.81s

root@3b21d4261c33:/src# cargo xclippy --target ps2.json
WARNING: There is no root package to read the cargo-xbuild config from.
    Checking prussia_rt v0.4.2 (/src/prussia_rt)
    Checking biostation v0.0.0 (/src/biostation)
    Checking hello-rs v0.1.0 (/src/hello-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 1.99s
```